### PR TITLE
Fixed "Company Website" hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # 🚀qmrExchange🚀
 **Quantitative Methods Research - QMR**
-**[🌐 Company Website](www.qmr.ai) / [🗎 Documentation](https://qmresearch.github.io/qmrExchange/source/index.html)** 
+**[🌐 Company Website](https://www.qmr.ai) / [🗎 Documentation](https://qmresearch.github.io/qmrExchange/source/index.html)** 
 
 - [🚀qmrExchange🚀](#qmrexchange)
   - [qmrExchange Overview](#qmrexchange-overview)


### PR DESCRIPTION
Redirects user to "https://github.com/QMResearch/qmrExchange/blob/master/www.qmr.ai" instead of the website link.